### PR TITLE
Fix camera crash

### DIFF
--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -421,7 +421,10 @@ public class Camera {
   }
 
   public void startPreview() throws CameraAccessException {
-    createCaptureSession(CameraDevice.TEMPLATE_PREVIEW, pictureImageReader.getSurface());
+    // Fix for: https://github.com/flutter/flutter/issues/19595
+    if (pictureImageReader != null) {
+      createCaptureSession(CameraDevice.TEMPLATE_PREVIEW, pictureImageReader.getSurface());
+    }
   }
 
   public void startPreviewWithImageStream(EventChannel imageStreamChannel)


### PR DESCRIPTION
According to https://github.com/flutter/flutter/issues/19595 startPreview method was causing random crashes because it is getting surface from uninitialized pictureImageReader